### PR TITLE
Release/1.0.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,6 @@ node_modules/
 package-lock.json
 images/
 .prettierrc.json
+tests/
+.editorconfig
+jest.config.ts

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.1.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-easy",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "description": "Easy twitch api wrapper",
   "main": "lib/index.js",
   "types": "lib",

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -1,3 +1,2 @@
 export * from './auth.declaration';
-export * from './auth.memory';
 export * from './auth';

--- a/src/services/http/index.ts
+++ b/src/services/http/index.ts
@@ -1,3 +1,2 @@
 export * from './http.declaration';
-export * from './http.memory';
 export * from './http';

--- a/tests/unit/modules/clips.test.ts
+++ b/tests/unit/modules/clips.test.ts
@@ -1,5 +1,7 @@
 import { Clips } from '../../../src/modules';
-import { AuthMemory, HttpMemory, IAuth, IHttp } from '../../../src/services';
+import { IAuth, IHttp } from '../../../src/services';
+import { AuthMemory } from '../../../src/services/auth/auth.memory';
+import { HttpMemory } from '../../../src/services/http/http.memory';
 
 describe('Clips', () => {
     const dataMock = [

--- a/tests/unit/modules/games.test.ts
+++ b/tests/unit/modules/games.test.ts
@@ -1,5 +1,7 @@
 import { Games } from '../../../src/modules';
-import { AuthMemory, HttpMemory, IAuth, IHttp } from '../../../src/services';
+import { IAuth, IHttp } from '../../../src/services';
+import { AuthMemory } from '../../../src/services/auth/auth.memory';
+import { HttpMemory } from '../../../src/services/http/http.memory';
 
 describe('Games', () => {
     const dataMockTop = [

--- a/tests/unit/modules/streamers.test.ts
+++ b/tests/unit/modules/streamers.test.ts
@@ -1,5 +1,7 @@
 import { Streamers } from '../../../src/modules';
-import { AuthMemory, HttpMemory, IAuth, IHttp } from '../../../src/services';
+import { IAuth, IHttp } from '../../../src/services';
+import { AuthMemory } from '../../../src/services/auth/auth.memory';
+import { HttpMemory } from '../../../src/services/http/http.memory';
 
 describe('Streamers', () => {
     const dataMockStreamer = {


### PR DESCRIPTION
- Updated version to **1.0.0**
- Updated typecript to 5.1.3
- Change export to `memory.ts`
  - Now, memory dont build with rest of code.